### PR TITLE
Add support to MySQL for keyword LIKE, add support to laravel 5.4.* for relation keys and other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ sw | Starts with | `Gior` matches `Giordano Bruno` but not `Giovanni`
 ew | Ends with | `uno` matches `Giordano Bruno` but not `Giovanni`
 eq | Equals | `Giordano Bruno` matches `Giordano Bruno` but not `Bruno`
 gt | Greater than | `1548` matches `1600` but not `1400`
+gte| Greater than or equalTo | `1548` matches `1548` and above
 lt | Lesser than | `1600` matches `1548` but not `1700`
+lte | Lesser than or equalTo | `1600` matches `1600` and below
 in | In array | `['Giordano', 'Bruno']` matches `Giordano` and `Bruno` but not `Giovanni`
 
 **Special values**

--- a/README.md
+++ b/README.md
@@ -31,8 +31,14 @@ To get started with Bruno I highly recommend my article on
 
 ## Installation
 
+For Laravel 5.3 and below
 ```bash
-composer require optimus/bruno ~1.0
+composer require optimus/bruno ~2.0
+```
+
+For Laravel 5.4 and above
+```bash
+composer require optimus/bruno ~3.0
 ```
 
 ## Usage
@@ -181,9 +187,9 @@ sw | Starts with | `Gior` matches `Giordano Bruno` but not `Giovanni`
 ew | Ends with | `uno` matches `Giordano Bruno` but not `Giovanni`
 eq | Equals | `Giordano Bruno` matches `Giordano Bruno` but not `Bruno`
 gt | Greater than | `1548` matches `1600` but not `1400`
-gte| Greater than or equalTo | `1548` matches `1548` and above
+gte| Greater than or equalTo | `1548` matches `1548` and above (ony for Laravel 5.4 and above)
+lte | Lesser than or equalTo | `1600` matches `1600` and below (ony for Laravel 5.4 and above)
 lt | Lesser than | `1600` matches `1548` but not `1700`
-lte | Lesser than or equalTo | `1600` matches `1600` and below
 in | In array | `['Giordano', 'Bruno']` matches `Giordano` and `Bruno` but not `Giovanni`
 
 **Special values**

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         }
     },
     "require": {
-        "laravel/framework": "~5.1",
+        "laravel/framework": "~5.4",
         "optimus/architect": "~1.0"
     },
     "require-dev": {

--- a/src/EloquentBuilderTrait.php
+++ b/src/EloquentBuilderTrait.php
@@ -20,40 +20,42 @@ trait EloquentBuilderTrait
      */
     protected function applyResourceOptions(Builder $queryBuilder, array $options = [])
     {
-        if (!empty($options)) {
-            extract($options);
+        if (empty($options)) {
+            return $queryBuilder;
+        }
 
-            if (isset($includes)) {
-                if (!is_array($includes)) {
-                    throw new InvalidArgumentException('Includes should be an array.');
-                }
+        extract($options);
 
-                $queryBuilder->with($includes);
+        if (isset($includes)) {
+            if (!is_array($includes)) {
+                throw new InvalidArgumentException('Includes should be an array.');
             }
 
-            if (isset($filter_groups)) {
-                $filterJoins = $this->applyFilterGroups($queryBuilder, $filter_groups);
+            $queryBuilder->with($includes);
+        }
+
+        if (isset($filter_groups)) {
+            $filterJoins = $this->applyFilterGroups($queryBuilder, $filter_groups);
+        }
+
+        if (isset($sort)) {
+            if (!is_array($sort)) {
+                throw new InvalidArgumentException('Sort should be an array.');
             }
 
-            if (isset($sort)) {
-                if (!is_array($sort)) {
-                    throw new InvalidArgumentException('Sort should be an array.');
-                }
-
-                if (!isset($filterJoins)) {
-                    $filterJoins = [];
-                }
-
-                $sortingJoins = $this->applySorting($queryBuilder, $sort, $filterJoins);
+            if (!isset($filterJoins)) {
+                $filterJoins = [];
             }
 
-            if (isset($limit)) {
-                $queryBuilder->limit($limit);
-            }
+            $sortingJoins = $this->applySorting($queryBuilder, $sort, $filterJoins);
+        }
 
-            if (isset($page)) {
-                $queryBuilder->offset($page*$limit);
-            }
+        if (isset($limit)) {
+            $queryBuilder->limit($limit);
+        }
+
+        if (isset($page)) {
+            $queryBuilder->offset($page*$limit);
         }
 
         return $queryBuilder;

--- a/src/EloquentBuilderTrait.php
+++ b/src/EloquentBuilderTrait.php
@@ -5,7 +5,6 @@ namespace Optimus\Bruno;
 use DB;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Support\Facades\Config;
 use InvalidArgumentException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Str;
@@ -99,7 +98,7 @@ trait EloquentBuilderTrait
         // $value, $not, $key, $operator
         extract($filter);
 
-        $dbType = Config::get('database.default');
+        $dbType = $queryBuilder->getConnection()->getDriverName();
 
         $table = $queryBuilder->getModel()->getTable();
 

--- a/src/EloquentBuilderTrait.php
+++ b/src/EloquentBuilderTrait.php
@@ -134,8 +134,14 @@ trait EloquentBuilderTrait
                 case 'gt':
                     $clauseOperator = $not ? '<' : '>';
                     break;
+                case 'gte':
+                    $clauseOperator = $not ? '<' : '>=';
+                    break;
                 case 'bt':
                     $clauseOperator = 'between';
+                    break;
+                case 'lte':
+                    $clauseOperator = $not ? '>' : '<=';
                     break;
                 case 'lt':
                     $clauseOperator = $not ? '>' : '<';

--- a/src/EloquentBuilderTrait.php
+++ b/src/EloquentBuilderTrait.php
@@ -137,9 +137,6 @@ trait EloquentBuilderTrait
                 case 'gte':
                     $clauseOperator = $not ? '<' : '>=';
                     break;
-                case 'bt':
-                    $clauseOperator = 'between';
-                    break;
                 case 'lte':
                     $clauseOperator = $not ? '>' : '<=';
                     break;

--- a/src/EloquentBuilderTrait.php
+++ b/src/EloquentBuilderTrait.php
@@ -59,6 +59,12 @@ trait EloquentBuilderTrait
         return $queryBuilder;
     }
 
+    /**
+     * @param Builder $queryBuilder
+     * @param array $filterGroups
+     * @param array $previouslyJoined
+     * @return array
+     */
     protected function applyFilterGroups(Builder $queryBuilder, array $filterGroups = [], array $previouslyJoined = [])
     {
         $joins = [];
@@ -80,6 +86,12 @@ trait EloquentBuilderTrait
         return $joins;
     }
 
+    /**
+     * @param Builder $queryBuilder
+     * @param array $filter
+     * @param bool|false $or
+     * @param array $joins
+     */
     protected function applyFilter(Builder $queryBuilder, array $filter, $or = false, array &$joins)
     {
         // $value, $not, $key, $operator
@@ -170,6 +182,12 @@ trait EloquentBuilderTrait
         }
     }
 
+    /**
+     * @param Builder $queryBuilder
+     * @param array $sorting
+     * @param array $previouslyJoined
+     * @return array
+     */
     protected function applySorting(Builder $queryBuilder, array $sorting, array $previouslyJoined = [])
     {
         $joins = [];
@@ -199,6 +217,11 @@ trait EloquentBuilderTrait
         return $joins;
     }
 
+    /**
+     * @param $type
+     * @param $key
+     * @return bool|string
+     */
     private function hasCustomMethod($type, $key)
     {
         $methodName = sprintf('%s%s', $type, Str::studly($key));
@@ -209,6 +232,10 @@ trait EloquentBuilderTrait
         return false;
     }
 
+    /**
+     * @param Builder $queryBuilder
+     * @param $key
+     */
     private function joinRelatedModelIfExists(Builder $queryBuilder, $key)
     {
         $model = $queryBuilder->getModel();

--- a/src/EloquentBuilderTrait.php
+++ b/src/EloquentBuilderTrait.php
@@ -221,9 +221,9 @@ trait EloquentBuilderTrait
             if ($relation instanceof BelongsTo) {
                 $query->join(
                     $relation->getRelated()->getTable(),
-                    $model->getTable().'.'.$relation->getForeignKey(),
+                    $model->getTable().'.'.$relation->getQualifiedForeignKeyName(),
                     '=',
-                    $relation->getRelated()->getTable().'.'.$relation->getOtherKey(),
+                    $relation->getRelated()->getTable().'.'.$relation->getOwnerKey(),
                     $type
                 );
             } elseif ($relation instanceof BelongsToMany) {
@@ -231,14 +231,14 @@ trait EloquentBuilderTrait
                     $relation->getTable(),
                     $relation->getQualifiedParentKeyName(),
                     '=',
-                    $relation->getForeignKey(),
+                    $relation->getQualifiedForeignKeyName(),
                     $type
                 );
                 $query->join(
                     $relation->getRelated()->getTable(),
                     $relation->getRelated()->getTable().'.'.$relation->getRelated()->getKeyName(),
                     '=',
-                    $relation->getOtherKey(),
+                    $relation->getQualifiedRelatedKeyName(),
                     $type
                 );
             } else {
@@ -246,7 +246,7 @@ trait EloquentBuilderTrait
                     $relation->getRelated()->getTable(),
                     $relation->getQualifiedParentKeyName(),
                     '=',
-                    $relation->getForeignKey(),
+                    $relation->getQualifiedForeignKeyName(),
                     $type
                 );
             }

--- a/src/LaravelController.php
+++ b/src/LaravelController.php
@@ -2,7 +2,9 @@
 
 namespace Optimus\Bruno;
 
+use JsonSerializable;
 use InvalidArgumentException;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Routing\Controller;
 use Illuminate\Routing\Router;
 use Illuminate\Http\JsonResponse;
@@ -10,6 +12,10 @@ use Optimus\Architect\Architect;
 
 abstract class LaravelController extends Controller
 {
+    /**
+     * Defaults
+     * @var array
+     */
     protected $defaults = [];
 
     /**
@@ -37,11 +43,16 @@ abstract class LaravelController extends Controller
      */
     protected function parseData($data, array $options, $key = null)
     {
-        $architect = new Architect;
+        $architect = new Architect();
 
         return $architect->parseData($data, $options['modes'], $key);
     }
 
+    /**
+     * Page sort
+     * @param array $sort
+     * @return array
+     */
     protected function parseSort(array $sort) {
         return array_map(function($sort) {
             if (!isset($sort['direction'])) {
@@ -82,7 +93,7 @@ abstract class LaravelController extends Controller
      * Parse filter group strings into filters
      * Filters are formatted as key:operator(value)
      * Example: name:eq(esben)
-     * @param  array  $filters
+     * @param  array  $filter_groups
      * @return array
      */
     protected function parseFilterGroups(array $filter_groups)


### PR DESCRIPTION
The keyword ILIKE can be used instead of LIKE to make the match case insensitive according to the active locale. This is not in the SQL standard but is a PostgreSQL extension.