### PR TITLE
fix boolean casting for filterGroup $or

### DIFF
--- a/src/LaravelController.php
+++ b/src/LaravelController.php
@@ -116,7 +116,7 @@ abstract class LaravelController extends Controller
 
             $return[] = [
                 'filters' => $filters,
-                'or' => isset($group['or']) ? $group['or'] : false
+                'or' => isset($group['or']) ? filter_var($group['or'], FILTER_VALIDATE_BOOLEAN) : false
             ];
         }
 


### PR DESCRIPTION
This will fix the issue of boolean casting for filterGroup. Now it supports string in boolean value. i.e. it parse "true"  to true and "false" to false.