### PR TITLE
Added default value to $join variable on applyFilter function

### DIFF
--- a/src/EloquentBuilderTrait.php
+++ b/src/EloquentBuilderTrait.php
@@ -103,7 +103,7 @@ trait EloquentBuilderTrait
      * @param bool|false $or
      * @param array $joins
      */
-    protected function applyFilter(Builder $queryBuilder, array $filter, $or = false, array &$joins)
+    protected function applyFilter(Builder $queryBuilder, array $filter, $or = false, array &$joins = [])
     {
         // Destructure Shorthand Filtering Syntax if filter is Shorthand
         if (! array_key_exists('key', $filter) && count($filter) >= 3) {


### PR DESCRIPTION
Leaving the $join variable blank when using PHP 8 causes an exception when running artisan. 

An empty array has been assigned to the variable to prevent this from happening.